### PR TITLE
Add fastpass-config to classpath for native-image

### DIFF
--- a/link-fastpass.sh
+++ b/link-fastpass.sh
@@ -1,7 +1,7 @@
 set -eux
 VERSION=$1
 NATIVE=$(~/.jabba/bin/jabba which --home graalvm@19.3.1)/bin/native-image
-$NATIVE -cp $(cs fetch org.scalameta:metals_2.12:$VERSION -p -r sonatype:snapshots) \
+$NATIVE -cp $(cs fetch org.scalameta:metals_2.12:$VERSION -p -r sonatype:snapshots):fastpass-config \
   --initialize-at-build-time \
   --initialize-at-run-time=scala.meta.internal.pantsbuild,metaconfig \
   --no-server \


### PR DESCRIPTION
This allows the user to create a `fastpass-config/fastpass.properties` file to set Zipkin trace properties at build time. See: https://github.com/scalameta/metals/pull/1582